### PR TITLE
Backport: add an event emitter to the worker

### DIFF
--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const EventEmitter = require('events');
 const _ = require('lodash');
 const co = require('co');
 const url = require('url');
@@ -39,6 +40,7 @@ const DEFAULT_EXCHANGE_TYPE = 'topic';
  * @returns {Object} a worker instance with connection, channel, and listen/close functions
  */
 function createWorkers(handlers, config, options = {}) {
+  const emitter = new EventEmitter();
   const workerConfig = applyConfiguration(Object.assign({}, { handlers }, config));
   const workerOptions = applyOptions(options);
   const configuration = Object.assign({}, workerConfig, workerOptions);
@@ -47,12 +49,71 @@ function createWorkers(handlers, config, options = {}) {
 
   let workerConnection;
   const workerChannels = [];
+
+  const TASK_COMPLETED = 'task.completed';
+  const TASK_RETRIED = 'task.retried';
+  const TASK_FAILED = 'task.failed';
+  const WORKER_CLOSED = 'task.closed';
+
   const logger = configuration.logger;
 
   return {
     listen: co.wrap(_listen),
-    close: co.wrap(_close)
+    close: co.wrap(_close),
+    wait: _wait,
+    TASK_COMPLETED,
+    TASK_RETRIED,
+    TASK_FAILED,
+    WORKER_CLOSED
   };
+
+  /**
+   * Wait for an event for a given amount of time.
+   *
+   * @param {string} eventName The name of the event to wait for.
+   * @param {number} timeout The maximum number of milliseconds to wait for, defaults to 1000.
+   * @return {Promise} A promise which is resolved when the event emitted, or rejected
+   * if the timeout occurs first.
+   * @private
+   */
+  function _wait(eventName, timeout = 1000) {
+    return new Promise((resolve, reject) => {
+      let timeoutId = null;
+
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
+        reject(new Error(`event ${eventName} didn't occur after ${timeout}ms`));
+      }, timeout);
+
+      emitter.once(eventName, () => {
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Emit an event with the provided name.
+   *
+   * Emission is scheduled with process.nextTick to allow current work to complete.
+   *
+   * @param {string} eventName the name of the event to publish
+   * @returns {void}
+   */
+  function _emit(eventName) {
+    process.nextTick(() => emitter.emit(eventName));
+  }
+
+  /**
+   * Exits the process after having emited the worker close event.
+   * @returns {void}
+   */
+  function _exit() {
+    _emit('worker.closed');
+    process.exit(0);
+  }
 
   /**
    * Listen to the queue and consume any matching message posted
@@ -62,7 +123,7 @@ function createWorkers(handlers, config, options = {}) {
    */
   function* _listen() {
     workerConnection = yield _connectAmqp(configuration);
-    workerOptions.logger.info(
+    logger.info(
       { options: configWithoutFuncs, workerName: configuration.workerName },
       '[worker#listen] worker started'
     );
@@ -83,7 +144,7 @@ function createWorkers(handlers, config, options = {}) {
     );
     yield workerChannels.map(channel => channel.close());
     if (workerConnection) yield workerConnection.close(forceExit);
-    if (forceExit) setTimeout(process.exit, configuration.processExitTimeout);
+    if (forceExit) setTimeout(_exit, configuration.processExitTimeout);
   }
 
   /**
@@ -127,6 +188,7 @@ function createWorkers(handlers, config, options = {}) {
       const contentString = message && message.content && message.content.toString();
       return JSON.parse(contentString);
     } catch (err) {
+      _emit('task.failed');
       logger.warn(
         { err, message, options: configWithoutFuncs },
         '[worker#listen] Content is not a valid JSON'
@@ -148,6 +210,7 @@ function createWorkers(handlers, config, options = {}) {
     try {
       return validate(message);
     } catch (err) {
+      _emit('task.failed');
       logger.warn(
         { err, message, options: configWithoutFuncs, workerName },
         '[worker#listen] Message validation failed'
@@ -169,6 +232,7 @@ function createWorkers(handlers, config, options = {}) {
     const { workerName, taskTimeout } = configuration;
     try {
       yield promisifyWithTimeout(handler(content, fields), workerName, taskTimeout);
+      _emit('task.completed');
       return true;
     } catch (err) {
       if (!fields.redelivered) {
@@ -176,12 +240,14 @@ function createWorkers(handlers, config, options = {}) {
           { err, content, options: configWithoutFuncs, workerName },
           '[worker#listen] Message handler failed to process message #1 - retrying one time'
         );
+        _emit('task.retried');
         return false;
       }
       logger.error(
         { err, content, options: configWithoutFuncs, workerName },
         '[worker#listen] Consumer handler failed to process message #2 - discard message and fail'
       );
+      _emit('task.failed');
       return true;
     }
   }

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -11,6 +11,12 @@ const { applyConfiguration, applyOptions } = require('./schema/createWorkers.sch
 
 const DEFAULT_EXCHANGE_TYPE = 'topic';
 
+// constants for events
+const TASK_COMPLETED = 'task.completed';
+const TASK_RETRIED = 'task.retried';
+const TASK_FAILED = 'task.failed';
+const WORKER_CLOSED = 'task.closed';
+
 /**
  * @typedef Logger
  *
@@ -49,12 +55,6 @@ function createWorkers(handlers, config, options = {}) {
 
   let workerConnection;
   const workerChannels = [];
-
-  const TASK_COMPLETED = 'task.completed';
-  const TASK_RETRIED = 'task.retried';
-  const TASK_FAILED = 'task.failed';
-  const WORKER_CLOSED = 'task.closed';
-
   const logger = configuration.logger;
 
   return {
@@ -107,12 +107,12 @@ function createWorkers(handlers, config, options = {}) {
   }
 
   /**
-   * Exits the process after having emited the worker close event.
+   * Exits the process after having emitted the worker close event.
    * @returns {void}
    */
   function _exit() {
     _emit('worker.closed');
-    process.exit(0);
+    setTimeout(() => process.exit(0), configuration.processExitTimeout);
   }
 
   /**
@@ -144,7 +144,7 @@ function createWorkers(handlers, config, options = {}) {
     );
     yield workerChannels.map(channel => channel.close());
     if (workerConnection) yield workerConnection.close(forceExit);
-    if (forceExit) setTimeout(_exit, configuration.processExitTimeout);
+    if (forceExit) _exit();
   }
 
   /**

--- a/test/lib/worker.test.js
+++ b/test/lib/worker.test.js
@@ -67,6 +67,76 @@ describe('Worker library', () => {
     yield connection.close();
   });
 
+  describe('#wait', () => {
+    it('should throw an error after the specified timeout', function* test() {
+      const worker = createWorkers([{
+        handle: () => true,
+        validate: _.identity,
+        routingKey
+      }], {
+        workerName,
+        amqpUrl,
+        exchangeName,
+        queueName
+      });
+      let err = null;
+      try {
+        yield worker.wait('kk', 10);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).to.exist();
+      expect(err.toString()).to.equal('Error: event kk didn\'t occur after 10ms');
+      yield worker.close(false);
+    });
+
+    it('should not resolve the promise when the event occurs after the timeout', function* test() {
+      const worker = createWorkers(
+        [{
+          handle: function* handle() {
+            return true;
+          },
+          validate: _.identity,
+          routingKey
+        }],
+        {
+          workerName,
+          amqpUrl,
+          exchangeName,
+          queueName
+        }
+      );
+      yield worker.listen();
+
+      // store the promise for later to check that it's not
+      // modified on the event completion
+      const promise = worker.wait('task.completed', 0);
+
+      let err = null;
+      try {
+        yield promise;
+      } catch (e) {
+        err = e;
+      }
+      expect(err).to.exist();
+
+      channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
+      yield worker.wait('task.completed');
+
+      // check that the previously generated promise wasn't affected by the completion of the event
+      // after the timeout
+      err = null;
+      try {
+        yield promise;
+      } catch (e) {
+        err = e;
+      }
+      expect(err).to.exist();
+      expect(err.toString()).to.equal('Error: event task.completed didn\'t occur after 0ms');
+      yield worker.close(false);
+    });
+  });
+
   describe('#listening', () => {
     it('should log an error and throw if connection fails', function* test() {
       sandbox.stub(amqplib, 'connect').throws();
@@ -107,7 +177,7 @@ describe('Worker library', () => {
       }, { logger });
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer('test'));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.failed');
       expect(logger.warn).to.have.callCount(1);
       yield worker.close(false);
     });
@@ -133,7 +203,7 @@ describe('Worker library', () => {
       });
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent)));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.completed');
       expect(validatorCalled).to.be.true();
       expect(workerCalled).to.be.true();
       yield worker.close(false);
@@ -164,41 +234,7 @@ describe('Worker library', () => {
       });
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
-      yield cb => setTimeout(cb, 100);
-      expect(validatorCalled).to.be.true();
-      expect(workerCalled).to.be.false();
-      expect(logger.warn.called).to.be.true();
-      yield worker.close(false);
-      const message = yield channel.get(formattedQueueName);
-      expect(message).to.be.false();
-    });
-
-    it('should not call handler and fail if validator throws (legacy)', function* test() {
-      sandbox.spy(logger, 'warn');
-      let validatorCalled = false;
-      let workerCalled = false;
-      const worker = createWorkers([{
-        handle: function* handle() {
-          workerCalled = true;
-          return true;
-        },
-        validate: () => {
-          validatorCalled = true;
-          throw new Error('validator error test');
-        },
-        routingKey
-      }], {
-        workerName,
-        amqpUrl,
-        exchangeName,
-        queueName
-      }, {
-        processExitTimeout: 5000,
-        logger
-      });
-      yield worker.listen();
-      channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.failed');
       expect(validatorCalled).to.be.true();
       expect(workerCalled).to.be.false();
       expect(logger.warn.called).to.be.true();
@@ -227,7 +263,7 @@ describe('Worker library', () => {
       );
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.completed');
       expect(workerCalled).to.be.true();
       yield worker.close(false);
       const message = yield channel.get(formattedQueueName);
@@ -267,7 +303,8 @@ describe('Worker library', () => {
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
       channel.publish(exchangeName, routingKey2, new Buffer(JSON.stringify(messageContent2)));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.completed');
+      yield worker.wait('task.completed');
       expect(worker1CallParameter).to.deep.equal(messageContent2);
       expect(worker2CallParameter).to.deep.equal({ validated: true });
       yield worker.close(false);
@@ -310,7 +347,8 @@ describe('Worker library', () => {
       }, { logger });
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.retried');
+      yield worker.wait('task.completed');
       yield worker.close(false);
       expect(logger.warn.calledWithMatch(
         { workerName },
@@ -337,7 +375,8 @@ describe('Worker library', () => {
       }, { logger });
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
-      yield cb => setTimeout(cb, 100);
+      yield worker.wait('task.retried');
+      yield worker.wait('task.failed');
       yield worker.close(false);
       expect(logger.warn.calledWithMatch(
         { workerName },


### PR DESCRIPTION
### Purpose of this PR

- Add an event emitter to the worker for major steps: 
  - task completed
  - task retried
  - task failed
  - worker closed

This allows simpler testing and workflow control.

### Checks

- [ ] Documentation is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back

