### PR TITLE
TECH : 0.2.1 allow logger object to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,37 @@ Example:
       processExitTimeout: 3000
     });
 ```
+
+Spec:
+    
+    createWorkers(handlers, config, options = {})
+
+Create and return a worker instance.
+
+#### handlers
+
+An array of handlers to handle incoming messages, each handler is an object with the following keys:
+* `routingKey`: name of the routing key to bind to
+* `handle`: function to handle incoming messages (see example below)
+* `validate`: function validating incoming messages bodies (see example below). If the function does not throw, the message is considered valid
+
+#### config
+
+Configuration of the worker:
+* `amqpUrl`: url of the AMQP broker
+* `exchangeName`: name of the exchange to listen on
+* `queueName`: name of the queue to bind to / create
+* `workerName`: name of the worker, used for logging purposes
+
+#### options
+Optional parameters for the worker:
+* `heartbeat`: if provided, will override default [heartbeat](https://www.rabbitmq.com/heartbeats.html) value (in seconds, default 10)
+* `taskTimeout`: task timeout (maximum time in milliseconds allowed to be spent on message handling, default 30000)
+* `processExitTimeout`:  process exit timeout (maximum time in milliseconds the worker will wait for connections to close before forcing exit, default 3000)
+* `channelPrefetch`:  channel [prefetch](https://www.rabbitmq.com/consumer-prefetch.html) value (default 100)
+* `logger`:  logger object implementing common logging functions (debug, info, warn, error)
+
+
 ### Basic use
 
 To listen on channel:

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -50,7 +50,7 @@ function createWorkers(handlers, config, options = {}) {
   const workerConfig = applyConfiguration(Object.assign({}, { handlers }, config));
   const workerOptions = applyOptions(options);
   const configuration = Object.assign({}, workerConfig, workerOptions);
-  const configWithoutFuncs = _.omit(configuration, ['amqpUrl', 'handlers', 'validator']);
+  const configWithoutFuncs = _.omit(configuration, ['amqpUrl', 'handlers', 'validator', 'logger']);
   configWithoutFuncs.routingKeys = _.map(handlers, 'routingKey');
 
   let workerConnection;

--- a/lib/schema/common.schema.js
+++ b/lib/schema/common.schema.js
@@ -31,7 +31,7 @@ const baseOptionsSchema = Joi.object({
     info: /* istanbul ignore next */ () => null,
     warn: /* istanbul ignore next */ () => null,
     error: /* istanbul ignore next */ () => null
-  })
+  }).unknown()
 });
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stakhanov",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Purpose of this PR

- Allow logger objects to have other members and not only interface functions: ease integrations with custom loggers
- Remove logger object from logs

### Checks

- [ ] Documentation is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back

