### PR TITLE
Implement graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Example:
     }, {
       channelPrefetch: 50,
       taskTimeout: 30000,
-      processExitTimeout: 3000
+      processExitTimeout: 3000,
+      channelCloseTimeout: 500,
     });
 ```
 
@@ -68,6 +69,7 @@ Optional parameters for the worker:
 * `heartbeat`: if provided, will override default [heartbeat](https://www.rabbitmq.com/heartbeats.html) value (in seconds, default 10)
 * `taskTimeout`: task timeout (maximum time in milliseconds allowed to be spent on message handling, default 30000)
 * `processExitTimeout`:  process exit timeout (maximum time in milliseconds the worker will wait for connections to close before forcing exit, default 3000)
+* `channelCloseTimeout`:  timeout between channel cancelation and close (maximum time in milliseconds the worker will let unfinished messages processing before nacking them, default 500)
 * `channelPrefetch`:  channel [prefetch](https://www.rabbitmq.com/consumer-prefetch.html) value (default 100)
 * `logger`:  logger object implementing common logging functions (debug, info, warn, error)
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Optional parameters for the worker:
 * `taskTimeout`: task timeout (maximum time in milliseconds allowed to be spent on message handling, default 30000)
 * `processExitTimeout`:  process exit timeout (maximum time in milliseconds the worker will wait for connections to close before forcing exit, default 3000)
 * `channelCloseTimeout`:  timeout between channel cancelation and close (maximum time in milliseconds the worker will let unfinished messages processing before nacking them, default 500)
+* `closeOnSignals`:  listen to SIGINT/SIGTERM and call worker.close for a graceful shutdown (default false)
 * `channelPrefetch`:  channel [prefetch](https://www.rabbitmq.com/consumer-prefetch.html) value (default 100)
 * `logger`:  logger object implementing common logging functions (debug, info, warn, error)
 

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -17,6 +17,8 @@ const TASK_RETRIED = 'task.retried';
 const TASK_FAILED = 'task.failed';
 const WORKER_CLOSED = 'task.closed';
 
+const EXIT_SIGNALS = Object.freeze(['SIGINT', 'SIGTERM']);
+
 /**
  * @typedef Logger
  *
@@ -57,7 +59,7 @@ function createWorkers(handlers, config, options = {}) {
   const workerChannels = [];
   const logger = configuration.logger;
 
-  return {
+  const workers = {
     listen: co.wrap(_listen),
     close: co.wrap(_close),
     wait: _wait,
@@ -66,6 +68,8 @@ function createWorkers(handlers, config, options = {}) {
     TASK_FAILED,
     WORKER_CLOSED
   };
+
+  return workers;
 
   /**
    * Wait for an event for a given amount of time.
@@ -129,16 +133,44 @@ function createWorkers(handlers, config, options = {}) {
       '[worker#listen] worker started'
     );
     yield configuration.handlers.map(handler => _bindHandler(handler));
+    if (configuration.closeOnSignals) {
+      EXIT_SIGNALS.forEach(_closeOnSignal);
+    }
   }
+
+  /**
+   * Listen to exit signal such as SIGINT and close the workers
+   * @param {String} signal name (e.g. SIGINT)
+   * @returns {void}
+   * @private
+   */
+  function _closeOnSignal(signal) {
+    process.on(signal, onSignal);
+
+    /**
+     * @returns {void}
+     */
+    function onSignal() {
+      logger.info({ workerName: configuration.workerName, signal },
+        '[worker#listen] Received exit signal, stopping workers...');
+      workers.close(true);
+    }
+  }
+
 
   /**
    * Close the connection
    * @param {Boolean} forceExit if true (default), will force a process exit after
    * configured timeout
-   * @returns {*} -
+   * @returns {void}
    * @private
    */
   function* _close(forceExit = true) {
+    // assign to a new variable and reset the shared one to avoid race conditions
+    const openedConnection = workerConnection;
+    workerConnection = null;
+    if (!openedConnection) return;  // already closed
+
     logger.info(
       { options: configWithoutFuncs, workerName: configuration.workerName, forceExit },
       '[worker#close] Shutting down'
@@ -149,7 +181,7 @@ function createWorkers(handlers, config, options = {}) {
       '[worker#close] Stopped listening to messages'
     );
     yield cb => setTimeout(cb, configuration.channelCloseTimeout);
-    if (workerConnection) yield workerConnection.close(forceExit);
+    yield openedConnection.close(forceExit);
     logger.info(
       { workerName: configuration.workerName },
       '[worker#close] Closed AMQP connection'

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -143,8 +143,17 @@ function createWorkers(handlers, config, options = {}) {
       { options: configWithoutFuncs, workerName: configuration.workerName, forceExit },
       '[worker#close] Shutting down'
     );
-    yield workerChannels.map(channel => channel.close());
+    yield workerChannels.map(({ channel, consumerTag }) => channel.cancel(consumerTag));
+    logger.info(
+      { workerName: configuration.workerName },
+      '[worker#close] Stopped listening to messages'
+    );
+    yield cb => setTimeout(cb, configuration.channelCloseTimeout);
     if (workerConnection) yield workerConnection.close(forceExit);
+    logger.info(
+      { workerName: configuration.workerName },
+      '[worker#close] Closed AMQP connection'
+    );
     if (forceExit) yield _exit();
   }
 
@@ -362,7 +371,7 @@ function createWorkers(handlers, config, options = {}) {
  * @param   {function} handler.handle the message handler
  * @param   {function} handler.validate the message validator
  * @param   {String} handler.routingKey the routingKey to bind to
- * @returns {*} -
+ * @returns {void}
  * @private
  */
   function* _bindHandler({ routingKey, handle, validate }) {
@@ -375,13 +384,13 @@ function createWorkers(handlers, config, options = {}) {
       channelPrefetch,
       workerName
     });
-    workerChannels.push(workerChannel);
 
     yield workerChannel.bindQueue(formattedQueueName, exchangeName, routingKey);
-    yield workerChannel.consume(
+    const { consumerTag } = yield workerChannel.consume(
       formattedQueueName,
       co.wrap(_getMessageConsumer(workerChannel, handle, validate))
     );
+    workerChannels.push({ channel: workerChannel, consumerTag });
   }
 }
 

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -110,9 +110,10 @@ function createWorkers(handlers, config, options = {}) {
    * Exits the process after having emitted the worker close event.
    * @returns {void}
    */
-  function _exit() {
+  function* _exit() {
     _emit('worker.closed');
-    setTimeout(() => process.exit(0), configuration.processExitTimeout);
+    yield cb => setTimeout(cb, configuration.processExitTimeout);
+    process.exit(0);
   }
 
   /**
@@ -144,7 +145,7 @@ function createWorkers(handlers, config, options = {}) {
     );
     yield workerChannels.map(channel => channel.close());
     if (workerConnection) yield workerConnection.close(forceExit);
-    if (forceExit) _exit();
+    if (forceExit) yield _exit();
   }
 
   /**

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -196,25 +196,31 @@ function createWorkers(handlers, config, options = {}) {
    * @param {function} handle the message handler
    * @param {function} validate the message validator
    * @returns {function} The generator function that consumes an AMQP message
+   * @param {String} routingKey routing key to bind on
    * @private
    */
-  function _getMessageConsumer(channel, handle, validate) {
+  function _getMessageConsumer(channel, handle, validate, routingKey) {
     return function* _consumeMessage(message) {
-      logger.debug({ message }, '[worker#listen] received message');
+      try {
+        logger.debug({ message, routingKey }, '[worker#listen] received message');
 
-      const content = _parseMessage(message);
-      if (!content) return channel.ack(message);
+        const content = _parseMessage(message);
+        if (!content) return channel.ack(message);
 
-      const validatedContent = _validateMessage(validate, content);
-      if (_.isError(validatedContent)) return channel.ack(message);
+        const validatedContent = _validateMessage(validate, content);
+        if (_.isError(validatedContent)) return channel.ack(message);
 
-      const handleSuccess = yield _handleMessage(
-        handle,
-        validatedContent || content,
-        message.fields
-      );
-      if (!handleSuccess) return channel.nack(message);
-      return channel.ack(message);
+        const handleSuccess = yield _handleMessage(
+          handle,
+          validatedContent || content,
+          message.fields
+        );
+        if (!handleSuccess) return channel.nack(message);
+        return channel.ack(message);
+      } catch (err) {
+        logger.error({ err, routingKey }, '[worker#listen] failed to ack/nack');
+        return null;
+      }
     };
   }
 
@@ -420,7 +426,7 @@ function createWorkers(handlers, config, options = {}) {
     yield workerChannel.bindQueue(formattedQueueName, exchangeName, routingKey);
     const { consumerTag } = yield workerChannel.consume(
       formattedQueueName,
-      co.wrap(_getMessageConsumer(workerChannel, handle, validate))
+      co.wrap(_getMessageConsumer(workerChannel, handle, validate, routingKey))
     );
     workerChannels.push({ channel: workerChannel, consumerTag });
   }

--- a/lib/schema/common.schema.js
+++ b/lib/schema/common.schema.js
@@ -22,6 +22,7 @@ const baseOptionsSchema = Joi.object({
   taskTimeout: Joi.number().positive().default(DEFAULT_TASK_TIMEOUT),
   processExitTimeout: Joi.number().positive().default(DEFAULT_PROCESS_TIMEOUT),
   channelCloseTimeout: Joi.number().positive().default(DEFAULT_CHANNEL_CLOSE_TIMEOUT),
+  closeOnSignals: Joi.bool().default(false),
   channelPrefetch: Joi.number().positive().default(DEFAULT_PREFETCH),
   logger: Joi.object().keys({
     debug: Joi.func().required(),

--- a/lib/schema/common.schema.js
+++ b/lib/schema/common.schema.js
@@ -5,6 +5,7 @@ const Joi = require('joi');
 const DEFAULT_HEARTBEAT = 10;
 const DEFAULT_TASK_TIMEOUT = 30000;
 const DEFAULT_PROCESS_TIMEOUT = 3000;
+const DEFAULT_CHANNEL_CLOSE_TIMEOUT = 500;
 const DEFAULT_PREFETCH = 100;
 
 const handlerSchema = Joi.func().required();
@@ -20,6 +21,7 @@ const baseOptionsSchema = Joi.object({
   heartbeat: Joi.number().positive().default(DEFAULT_HEARTBEAT),
   taskTimeout: Joi.number().positive().default(DEFAULT_TASK_TIMEOUT),
   processExitTimeout: Joi.number().positive().default(DEFAULT_PROCESS_TIMEOUT),
+  channelCloseTimeout: Joi.number().positive().default(DEFAULT_CHANNEL_CLOSE_TIMEOUT),
   channelPrefetch: Joi.number().positive().default(DEFAULT_PREFETCH),
   logger: Joi.object().keys({
     debug: Joi.func().required(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stakhanov",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {

--- a/test/lib/worker.test.js
+++ b/test/lib/worker.test.js
@@ -423,9 +423,9 @@ describe('Worker library', () => {
     });
   });
 
-  describe('forceExit parameter setting', () => {
-    it('should forcefully exit process on worker close', function* test() {
-      sandbox.stub(process, 'exit');
+  describe('#close', () => {
+    it('should forcefully exit process on worker close (forceExit=true)', function* test() {
+      const exitStub = sandbox.stub(process, 'exit');
       const worker = createWorkers([{
         handle: _.identity,
         validate: _.identity,
@@ -442,8 +442,30 @@ describe('Worker library', () => {
         });
       yield worker.listen();
       yield worker.close();
-      yield cb => setTimeout(cb, 500);
-      expect(process.exit.called).to.be.true();
+      expect(exitStub.args).to.deep.equal([
+        [0]
+      ]);
+    });
+
+    it('should not exit process on worker close (forceExit=false)', function* test() {
+      const exitStub = sandbox.stub(process, 'exit');
+      const worker = createWorkers([{
+        handle: _.identity,
+        validate: _.identity,
+        routingKey
+      }],
+        {
+          workerName,
+          amqpUrl,
+          exchangeName,
+          queueName
+        }, {
+          processExitTimeout: 1,
+          logger
+        });
+      yield worker.listen();
+      yield worker.close(false);
+      expect(exitStub.args).to.deep.equal([]);
     });
   });
 

--- a/test/lib/worker.test.js
+++ b/test/lib/worker.test.js
@@ -303,8 +303,9 @@ describe('Worker library', () => {
       yield worker.listen();
       channel.publish(exchangeName, routingKey, new Buffer(JSON.stringify(messageContent2)));
       channel.publish(exchangeName, routingKey2, new Buffer(JSON.stringify(messageContent2)));
-      yield worker.wait('task.completed');
-      yield worker.wait('task.completed');
+      while (!(worker1CallParameter && worker2CallParameter)) {
+        yield worker.wait('task.completed');
+      }
       expect(worker1CallParameter).to.deep.equal(messageContent2);
       expect(worker2CallParameter).to.deep.equal({ validated: true });
       yield worker.close(false);


### PR DESCRIPTION
### Purpose of this PR

Implement graceful shutdown for workers
- cancel channels and wait before closing the connection => gives some time to end unfinished tasks and ack them
- make it possible to call the close method when receiving SIGINT/SIGTERM and actually use the graceful shutdown when stopping the server
- close is idempotent and race-condition free (necessary for the previous dev to be safe)

More detailed description in the commit messages.

### Configuration change

Added 2 options (documented in the README)

### Checks

- [ ] Documentation is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back


### Linked PRs:

- ...
