### PR TITLE
TECH : remove reference to NPM_TOKEN

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 save-prefix=


### PR DESCRIPTION
### Purpose of this PR

The .npmrc file contained `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` which made any build fail if the PR branch was coming from an outside repository, as the environment variables are all removed by CircleCi when building a remote branch.

The NPM_TOKEN is not needed anyway here since this is an open-source project.

### Checks

- [ ] Documentation is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back

