### PR TITLE
TRAN-17740 : add support for defining exchange type and queue options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ An array of handlers to handle incoming messages, each handler is an object with
 Configuration of the worker:
 * `amqpUrl`: url of the AMQP broker
 * `exchangeName`: name of the exchange to listen on
+* `exchangeType`: type of the exchange (default to `topic`)
 * `queueName`: name of the queue to bind to / create
+* `queueoptions`: queue options (default to `{}`)
 * `workerName`: name of the worker, used for logging purposes
 
 #### options

--- a/lib/createWorkers.js
+++ b/lib/createWorkers.js
@@ -9,8 +9,6 @@ const amqplib = require('amqplib');
 const { promisifyWithTimeout } = require('./lib');
 const { applyConfiguration, applyOptions } = require('./schema/createWorkers.schema');
 
-const DEFAULT_EXCHANGE_TYPE = 'topic';
-
 // constants for events
 const TASK_COMPLETED = 'task.completed';
 const TASK_RETRIED = 'task.retried';
@@ -38,7 +36,9 @@ const EXIT_SIGNALS = Object.freeze(['SIGINT', 'SIGTERM']);
  * @param {String} config.workerName name for the worker
  * @param {String} config.amqpUrl url to amqp server
  * @param {String} config.exchangeName name of the exchange to use
+ * @param {String} [config.exchangeType=topic] the exchange type to use
  * @param {String} config.queueName name of the queue to listen on
+ * @param {Object} [config.queueOptions={}] queue options
  * @param {Object} [options] additional options
  * @param {Number} [options.heartbeat] to override default heartbeat
  * @param {Number} [options.taskTimeout] to override default task timeout
@@ -378,7 +378,9 @@ function createWorkers(handlers, config, options = {}) {
    * Create a channel for the worker
    * @param {Object} connection the connection object
    * @param {String} exchangeName the exchange name to use
+   * @param {String} exchangeType the exchange type to use
    * @param {String} queueName the queue name to target
+   * @param {Object} queueOptions queue options to use
    * @param {String} routingKey routing key to bind on
    * @param {Number} channelPrefetch number of message to prefetch from channel
    * @param {String} workerName the name of the worker (for logs)
@@ -386,7 +388,7 @@ function createWorkers(handlers, config, options = {}) {
    * @private
    */
   function* _createChannel(connection,
-    { exchangeName, queueName, channelPrefetch, workerName }) {
+    { exchangeName, exchangeType, queueName, queueOptions, channelPrefetch, workerName }) {
     const channel = yield connection.createChannel();
     logger.info(
       { exchangeName, queueName, channelPrefetch, workerName },
@@ -397,8 +399,8 @@ function createWorkers(handlers, config, options = {}) {
       { exchangeName, queueName, channelPrefetch, workerName }
     );
     yield channel.prefetch(channelPrefetch);
-    yield channel.assertExchange(exchangeName, DEFAULT_EXCHANGE_TYPE);
-    yield channel.assertQueue(queueName, {});
+    yield channel.assertExchange(exchangeName, exchangeType);
+    yield channel.assertQueue(queueName, queueOptions);
     return channel;
   }
 
@@ -413,12 +415,21 @@ function createWorkers(handlers, config, options = {}) {
  * @private
  */
   function* _bindHandler({ routingKey, handle, validate }) {
-    const { exchangeName, queueName, channelPrefetch, workerName } = configuration;
+    const {
+      exchangeName,
+      exchangeType,
+      queueName,
+      queueOptions,
+      channelPrefetch,
+      workerName
+    } = configuration;
     const formattedQueueName = _getQueueName(queueName, routingKey);
 
     const workerChannel = yield _createChannel(workerConnection, {
       exchangeName,
+      exchangeType,
       queueName: formattedQueueName,
+      queueOptions,
       channelPrefetch,
       workerName
     });

--- a/lib/schema/common.schema.js
+++ b/lib/schema/common.schema.js
@@ -7,6 +7,7 @@ const DEFAULT_TASK_TIMEOUT = 30000;
 const DEFAULT_PROCESS_TIMEOUT = 3000;
 const DEFAULT_CHANNEL_CLOSE_TIMEOUT = 500;
 const DEFAULT_PREFETCH = 100;
+const DEFAULT_EXCHANGE_TYPE = 'topic';
 
 const handlerSchema = Joi.func().required();
 
@@ -14,7 +15,9 @@ const baseConfigurationSchema = Joi.object({
   workerName: Joi.string().required(),
   amqpUrl: Joi.string().required(),
   exchangeName: Joi.string().required(),
-  queueName: Joi.string().required()
+  exchangeType: Joi.string().default(DEFAULT_EXCHANGE_TYPE),
+  queueName: Joi.string().required(),
+  queueOptions: Joi.object().default({})
 });
 
 const baseOptionsSchema = Joi.object({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stakhanov",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AMQP worker library",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Purpose of this PR

Add support for defining exchange type and queue options.
### Checks

- [ ] Documentation is very clear, even for a newcomer
- [ ] All relevant usecases of are tested
- [ ] These changes won't cause memory / CPU problems even if business grows by a factor of 100
- [ ] It's ok if these changes go to production and then are rolled-back
